### PR TITLE
Implement modular structure for mail service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=username
+SMTP_PASS=password
+MAIL_FROM=no-reply@example.com
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# Node Mail Service
+
+This project provides a simple REST API for sending templated emails from Node.js. It can run as a Windows service using **node-windows** and supports Handlebars templates with inline images.
+
+The codebase is organized into small modules under `src/` for easier maintenance:
+
+- `config.js` loads environment variables and verifies required settings.
+- `mailer.js` creates the Nodemailer transport and exports a `sendMail` helper.
+- `routes/` exposes REST endpoints consumed by `server.js`.
+
+## Setup
+
+1. Clone the repository and install dependencies:
+
+```bash
+npm install
+```
+
+2. Copy `.env.example` to `.env` and update the SMTP configuration and other environment variables:
+
+```bash
+cp .env.example .env
+```
+
+3. Start the service for development (runs `src/server.js`):
+
+```bash
+npm start
+```
+
+## Windows Service
+
+The included `service.js` script allows installing or uninstalling the REST API as a Windows service.
+
+```bash
+npm run install-service   # install and start the service
+npm run uninstall-service # uninstall the service
+```
+
+## REST API
+
+`POST /api/send`
+
+Payload example:
+
+```json
+{
+  "to": "user@example.com",
+  "subject": "Welcome",
+  "template": "welcome",
+  "context": { "name": "User" },
+  "attachments": [
+    {
+      "filename": "logo.png",
+      "path": "./path/to/logo.png",
+      "cid": "logo"
+    }
+  ]
+}
+```
+
+- `template` must match a file in the `templates` directory (without extension).
+- Attachments can be used to embed images referenced by `cid` in the template.
+
+## Templates
+
+Example templates are provided in the `templates/` folder. You can add more Handlebars templates to customize your emails.
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "node-mail-service",
+  "version": "1.0.0",
+  "description": "Turnkey REST mail service that can run as a Windows service",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "install-service": "node service.js install",
+    "uninstall-service": "node service.js uninstall",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "dotenv": "^16.0.3",
+    "express": "^4.18.2",
+    "node-windows": "^1.0.0",
+    "nodemailer": "^6.9.1",
+    "nodemailer-express-handlebars": "^7.0.1"
+  }
+}

--- a/service.js
+++ b/service.js
@@ -1,0 +1,25 @@
+const { Service } = require('node-windows');
+const path = require('path');
+
+const svc = new Service({
+  name: 'Node Mail Service',
+  description: 'REST-based mail sending service',
+  script: path.join(__dirname, 'src', 'server.js'),
+});
+
+const action = process.argv[2];
+
+if (action === 'install') {
+  svc.on('install', () => {
+    console.log('Service installed');
+    svc.start();
+  });
+  svc.install();
+} else if (action === 'uninstall') {
+  svc.on('uninstall', () => {
+    console.log('Service uninstalled');
+  });
+  svc.uninstall();
+} else {
+  console.log('Usage: node service.js install | uninstall');
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,29 @@
+require('dotenv').config();
+
+const required = [
+  'SMTP_HOST',
+  'SMTP_PORT',
+  'SMTP_USER',
+  'SMTP_PASS',
+  'MAIL_FROM'
+];
+
+for (const key of required) {
+  if (!process.env[key]) {
+    throw new Error(`Missing required env var: ${key}`);
+  }
+}
+
+module.exports = {
+  smtp: {
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT),
+    secure: process.env.SMTP_SECURE === 'true',
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS
+    }
+  },
+  mailFrom: process.env.MAIL_FROM,
+  port: process.env.PORT || 3000
+};

--- a/src/mailer.js
+++ b/src/mailer.js
@@ -1,0 +1,33 @@
+const nodemailer = require('nodemailer');
+const hbs = require('nodemailer-express-handlebars');
+const path = require('path');
+const config = require('./config');
+
+const transport = nodemailer.createTransport(config.smtp);
+
+const handlebarOptions = {
+  viewEngine: {
+    extname: '.hbs',
+    partialsDir: path.resolve('./templates'),
+    layoutsDir: path.resolve('./templates'),
+    defaultLayout: '',
+  },
+  viewPath: path.resolve('./templates'),
+  extName: '.hbs',
+};
+
+transport.use('compile', hbs(handlebarOptions));
+
+function sendMail({ to, subject, template, context = {}, attachments = [] }) {
+  const mailOptions = {
+    from: config.mailFrom,
+    to,
+    subject,
+    template,
+    context,
+    attachments,
+  };
+  return transport.sendMail(mailOptions);
+}
+
+module.exports = { sendMail };

--- a/src/routes/mailRoutes.js
+++ b/src/routes/mailRoutes.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const { sendMail } = require('../mailer');
+
+const router = express.Router();
+
+router.post('/send', async (req, res) => {
+  try {
+    const { to, subject, template, context, attachments } = req.body;
+    await sendMail({ to, subject, template, context, attachments });
+    res.status(200).json({ message: 'Mail sent' });
+  } catch (err) {
+    console.error('Mail send error', err);
+    res.status(500).json({ message: 'Failed to send mail', error: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const mailRoutes = require('./routes/mailRoutes');
+const config = require('./config');
+
+const app = express();
+const PORT = config.port;
+
+app.use(express.json());
+
+app.use('/api', mailRoutes);
+
+app.listen(PORT, () => {
+  console.log(`Mail service listening on port ${PORT}`);
+});

--- a/templates/reset-password.hbs
+++ b/templates/reset-password.hbs
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <p>Hello {{name}},</p>
+    <p>Click <a href="{{resetLink}}">here</a> to reset your password.</p>
+    <img src="cid:logo" alt="Logo" />
+  </body>
+</html>

--- a/templates/welcome.hbs
+++ b/templates/welcome.hbs
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <h1>Welcome {{name}}</h1>
+    <p>This email demonstrates inline images with Handlebars.</p>
+    <img src="cid:logo" alt="Logo" />
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- refactor project into `src/` directory for clarity
- add configuration loader with env validation
- separate mail sending logic into its own module
- expose routes via Express router
- update documentation and service path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882eb0c59308321aeb41379ab4f070d